### PR TITLE
move view button to better place

### DIFF
--- a/ui/walls.html
+++ b/ui/walls.html
@@ -3,11 +3,12 @@
   <table class="table table-bordered">
     <thead>
     <tr>
+      <th>view</th>
       <th>name</th>
       <th>boards</th>
       <th>created</th>
       <th>modified</th>
-      <th>action</th>
+      <th>demolish</th>
     </tr>
     </thead>
     <tbody>
@@ -37,12 +38,12 @@
       </td>
     </tr>
     <tr ng-repeat="wall in wallsCtrl.list">
+      <td><a type="button" class="btn btn-info" ui-sref="wall({name: wall.name})">View</a></td>
       <td>{{ wall.name }}</td>
       <td>{{ wall.boards.length }}</td>
       <td>{{ wall.created }}</td>
       <td>{{ wall.modified }}</td>
       <td>
-        <a type="button" class="btn btn-info" ui-sref="wall({name: wall.name})">View</a>
         <button type="button" class="btn btn-danger btn-sm pull-right"
                 ng-click="wallsCtrl.destroyWall(wall)">Demolish
         </button>


### PR DESCRIPTION
For
- ""Anvil: move "actions" (buttons) column to be first column blacklocus/blacklocus#4177""

Move "view" button to the leftmost, where it ought to be.

Old:

<img width="1658" alt="screen shot 2016-08-07 at 5 12 14 pm" src="https://cloud.githubusercontent.com/assets/9805790/17465624/30e30ec2-5cc2-11e6-8b70-3d9aadb75669.png">

New:

<img width="1654" alt="screen shot 2016-08-07 at 5 01 55 pm" src="https://cloud.githubusercontent.com/assets/9805790/17465584/afb61c50-5cc0-11e6-9645-9adbd2733e94.png">

Funny story, this is already deployed to anvil.blacklocus.com.
