### PR TITLE
Update anvil to support 15 months data

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
   ],
   "dependencies": {
     "moment": "~2.10.0",
+    "moment-duration-format": "~1.3.0",
     "bootstrap": "~3.3.4",
     "aws-sdk": "~2.1.21",
     "flot": "~0.8.3",

--- a/ui/app.html
+++ b/ui/app.html
@@ -19,6 +19,7 @@
   <script type="text/javascript" src="lib/bower_components/angular-ui-sortable/sortable.min.js"></script>
   <script type="text/javascript" src="lib/bower_components/angular-local-storage/dist/angular-local-storage.min.js"></script>
   <script type="text/javascript" src="lib/bower_components/chance/chance.js"></script>
+  <script type="text/javascript" src="lib/bower_components/moment-duration-format/lib/moment-duration-format.js"></script>
 
   <link rel="stylesheet" href="app.css"/>
   <script type="text/javascript" src="util.js"></script>

--- a/ui/board.controller.js
+++ b/ui/board.controller.js
@@ -11,9 +11,9 @@
     vm.minDataPoints = 10;
     vm.maxDataPoints = 1000;
 
-    vm.windowOpts = Util.toDurations(['2 weeks', '10 days', '1 week', '6 days', '5 days', '4 days', '3 days',
+    vm.windowOpts = Util.toDurations(['1.4 years', '12 months', '8 months', '6 months', '4 months', '2 months', '1 month', '2 weeks', '10 days', '1 week', '6 days', '5 days', '4 days', '3 days',
       '2 days', '1 day', '18 hours', '12 hours', '6 hours', '3 hours', '2 hours', '1 hour']);
-    vm.periodOpts = Util.toDurations(['1 day', '6 hours', '1 hour', '15 minutes', '5 minutes', '1 minute']);
+    vm.periodOpts = Util.toDurations(['1 month', '5 days', '10 days', '5 days', '2 days', '1 day', '6 hours', '1 hour', '15 minutes', '5 minutes', '1 minute']);
 
     vm.editingName = false;
 

--- a/ui/board.controller.js
+++ b/ui/board.controller.js
@@ -11,14 +11,21 @@
     vm.minDataPoints = 10;
     vm.maxDataPoints = 1000;
 
-    vm.windowOpts = Util.toDurations(['1.4 years', '12 months', '8 months', '6 months', '4 months', '2 months', '1 month', '2 weeks', '10 days', '1 week', '6 days', '5 days', '4 days', '3 days',
+    vm.windowOpts = Util.toDurations(['15 months', '12 months', '8 months', '6 months', '4 months', '2 months', '1 month', '2 weeks', '10 days', '1 week', '6 days', '5 days', '4 days', '3 days',
       '2 days', '1 day', '18 hours', '12 hours', '6 hours', '3 hours', '2 hours', '1 hour']);
-    vm.periodOpts = Util.toDurations(['1 month', '5 days', '10 days', '5 days', '2 days', '1 day', '6 hours', '1 hour', '15 minutes', '5 minutes', '1 minute']);
+    vm.periodOpts = Util.toDurations(['1 month', '15 days', '10 days', '5 days', '2 days', '1 day', '12 hours', '6 hours', '1 hour', '15 minutes', '5 minutes', '1 minute']);
 
     vm.editingName = false;
 
     vm.busy = false;
 
+    vm.humanizeDuration = function () {
+      var duration = vm.windowOpts[vm.selectedWindowIdx];
+      if (/P[0-9]+Y[0-9A-Z]*/.test(JSON.stringify(duration))) {
+        return duration.format("M [months]");
+      }
+      return duration.humanize();
+    };
 
     vm.selectedWindow = function () {
       return vm.windowOpts[vm.selectedWindowIdx];

--- a/ui/board.controller.js
+++ b/ui/board.controller.js
@@ -11,9 +11,35 @@
     vm.minDataPoints = 10;
     vm.maxDataPoints = 1000;
 
-    vm.windowOpts = Util.toDurations(['15 months', '12 months', '9 months', '6 months', '3 months', '2 months', '1 month', '15 days', '8 days', '5 days', '3 days',
-      '2 days', '1 day', '18 hours', '12 hours', '6 hours', '3 hours', '2 hours', '1 hour']);
-    vm.periodOpts = Util.toDurations(['1 day', '12 hours', '6 hours', '1 hour', '15 minutes', '5 minutes', '1 minute']);
+    vm.windowOpts = Util.toDurations([
+      '15 months',
+      '12 months',
+      '9 months',
+      '6 months',
+      '3 months',
+      '2 months',
+      '1 month',
+      '15 days',
+      '8 days',
+      '5 days',
+      '3 days',
+      '2 days',
+      '1 day',
+      '18 hours',
+      '12 hours',
+      '6 hours',
+      '3 hours',
+      '2 hours',
+      '1 hour']);
+
+    vm.periodOpts = Util.toDurations([
+      '1 day',
+      '12 hours',
+      '6 hours',
+      '1 hour',
+      '15 minutes',
+      '5 minutes',
+      '1 minute']);
 
     vm.editingName = false;
 

--- a/ui/board.controller.js
+++ b/ui/board.controller.js
@@ -171,7 +171,7 @@
             xaxis: {
               insertGaps: true,
               tickFormatter: function (val) {
-                return moment(val).format('HH:mm<br/>ddd M/D');
+                return moment(val).format('HH:mm<br/>ddd M/D/YY');
               }
             },
             yaxis: {

--- a/ui/board.controller.js
+++ b/ui/board.controller.js
@@ -11,9 +11,9 @@
     vm.minDataPoints = 10;
     vm.maxDataPoints = 1000;
 
-    vm.windowOpts = Util.toDurations(['15 months', '12 months', '8 months', '6 months', '4 months', '2 months', '1 month', '2 weeks', '10 days', '1 week', '6 days', '5 days', '4 days', '3 days',
+    vm.windowOpts = Util.toDurations(['15 months', '12 months', '9 months', '6 months', '3 months', '2 months', '1 month', '15 days', '8 days', '5 days', '3 days',
       '2 days', '1 day', '18 hours', '12 hours', '6 hours', '3 hours', '2 hours', '1 hour']);
-    vm.periodOpts = Util.toDurations(['1 month', '15 days', '10 days', '5 days', '2 days', '1 day', '12 hours', '6 hours', '1 hour', '15 minutes', '5 minutes', '1 minute']);
+    vm.periodOpts = Util.toDurations(['1 day', '12 hours', '6 hours', '1 hour', '15 minutes', '5 minutes', '1 minute']);
 
     vm.editingName = false;
 

--- a/ui/board.html
+++ b/ui/board.html
@@ -46,7 +46,7 @@
     <div class="col-sm-9">
       <div class="row">
           <span class="col-sm-4 text-right">
-            window of <strong>{{ boardCtrl.windowOpts[boardCtrl.selectedWindowIdx].humanize() }}</strong>
+            window of <strong>{{ boardCtrl.humanizeDuration() }}</strong>
           </span>
           <span class="col-sm-8">
             <input type="range" min="0" max="{{ boardCtrl.windowOpts.length - 1 }}"

--- a/ui/board.html
+++ b/ui/board.html
@@ -65,7 +65,7 @@
       </div>
       <div class="row">
           <span class="col-sm-4 text-right">
-            = up to <strong>{{ boardCtrl.selectedWindow() / boardCtrl.selectedPeriod() }}</strong> data points
+            = up to <strong>{{ boardCtrl.selectedWindow() / boardCtrl.selectedPeriod() | number:0 }}</strong> data points
           </span>
         <aside class="col-sm-8">
           ⇐ The sliders automatically adjust to maintain a reasonable number of data points


### PR DESCRIPTION
Description:
let Anvil can present up to 15 months data with more period options. And since the humanize() does not do a good job on window > 12 months. a customized humanize() is written to improve that.

Test:
- for all new window and period combinations, confirm the data points is between 10 - 1000, they will adjust automatically to fit into that range.
- new options on the fixed bar length work ok and easy to access and distinguish. 
- "Save as default" still work appropriately to keep the default window and period pair.